### PR TITLE
判断SPS、PPS、SEI帧并特殊处理

### DIFF
--- a/src/net/AACRtpSink.cpp
+++ b/src/net/AACRtpSink.cpp
@@ -73,7 +73,7 @@ std::string AACRtpSink::getAttribute()
     return std::string(buf);
 }
 
-void AACRtpSink::handleFrame(AVFrame* frame)
+int AACRtpSink::handleFrame(AVFrame* frame)
 {
     RtpHeader* rtpHeader = mRtpPacket.mRtpHeadr;
     int frameSize = frame->mFrameSize-7; //去掉aac头部
@@ -93,5 +93,7 @@ void AACRtpSink::handleFrame(AVFrame* frame)
 
     /* (1000 / mFps) 表示一帧多少毫秒 */
     mTimestamp += mSampleRate * (1000 / mFps) / 1000;
+
+    return 1;
 }
 

--- a/src/net/AACRtpSink.h
+++ b/src/net/AACRtpSink.h
@@ -17,7 +17,7 @@ public:
     virtual std::string getAttribute();
 
 protected:
-    virtual void handleFrame(AVFrame* frame);
+    virtual int handleFrame(AVFrame* frame);
 
 private:
     RtpPacket mRtpPacket;

--- a/src/net/H264RtpSink.cpp
+++ b/src/net/H264RtpSink.cpp
@@ -44,7 +44,7 @@ std::string H264RtpSink::getAttribute()
     return std::string(buf);
 }
 
-void H264RtpSink::handleFrame(AVFrame* frame)
+int H264RtpSink::handleFrame(AVFrame* frame)
 {
     RtpHeader* rtpHeader = mRtpPacket.mRtpHeadr;
     uint8_t naluType = frame->mFrame[0];
@@ -56,8 +56,8 @@ void H264RtpSink::handleFrame(AVFrame* frame)
         sendRtpPacket(&mRtpPacket);
         mSeq++;
 
-        if ((naluType & 0x1F) == 7 || (naluType & 0x1F) == 8) // 如果是SPS、PPS就不需要加时间戳
-            return;
+        if ((naluType & 0x1F) == 7 || (naluType & 0x1F) == 8 || (naluType & 0x1F) == 6) // 如果是SPS、PPS、SEI就不需要加时间戳
+            return 0;
     }
     else
     {
@@ -115,4 +115,5 @@ void H264RtpSink::handleFrame(AVFrame* frame)
     }
     
     mTimestamp += mClockRate/mFps;
+    return 1;
 }

--- a/src/net/H264RtpSink.h
+++ b/src/net/H264RtpSink.h
@@ -14,7 +14,7 @@ public:
 
     virtual std::string getMediaDescription(uint16_t port);
     virtual std::string getAttribute();
-    virtual void handleFrame(AVFrame* frame);
+    virtual int handleFrame(AVFrame* frame);
 
 private:
     RtpPacket mRtpPacket;

--- a/src/net/RtpSink.cpp
+++ b/src/net/RtpSink.cpp
@@ -52,7 +52,7 @@ void RtpSink::sendRtpPacket(RtpPacket* packet)
     rtpHead->timestamp = htonl(mTimestamp);
     rtpHead->ssrc = htonl(mSSRC);
     packet->mSize += RTP_HEADER_SIZE;
-    
+
     if(mSendPacketCallback)
         mSendPacketCallback(mArg1, mArg2, packet);
 }
@@ -60,15 +60,19 @@ void RtpSink::sendRtpPacket(RtpPacket* packet)
 void RtpSink::timeoutCallback(void* arg)
 {
     RtpSink* rtpSink = (RtpSink*)arg;
-    AVFrame* frame = rtpSink->mMediaSource->getFrame();
-    if(!frame)
-    {
-        return;
-    }
+    int Done = 0;
 
-    rtpSink->handleFrame(frame);
+    do {
+        AVFrame* frame = rtpSink->mMediaSource->getFrame();
+        if(!frame)
+        {
+            return;
+        } 
 
-    rtpSink->mMediaSource->putFrame(frame);
+        Done = rtpSink->handleFrame(frame);
+
+        rtpSink->mMediaSource->putFrame(frame);
+    } while(!Done);
 }
 
 void RtpSink::start(int ms)

--- a/src/net/RtpSink.h
+++ b/src/net/RtpSink.h
@@ -23,7 +23,7 @@ public:
     void setSendFrameCallback(SendPacketCallback cb, void* arg1, void* arg2);
 
 protected:
-    virtual void handleFrame(AVFrame* frame) = 0;
+    virtual int handleFrame(AVFrame* frame) = 0;
     void sendRtpPacket(RtpPacket* packet);
     void start(int ms);
     void stop();


### PR DESCRIPTION
h264的裸流可能存在周期性的SPS、PPS、SEI信息(特别是实时视频流)，对这些nal unit的处理除了不增加Rtp包的timestamp外，还得紧接着发送下一个nal unit(而不是等待下一个timer callback)，否则rtsp client那边收到的帧率、码率都会偏低。